### PR TITLE
Remove unused dependencies

### DIFF
--- a/activiti-kickstart-rest/pom.xml
+++ b/activiti-kickstart-rest/pom.xml
@@ -1,156 +1,210 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<?xml version="1.0" encoding="UTF-8"?>
 
-	<name>Activiti - KickStart - REST</name>
-	<artifactId>activiti-kickstart-rest</artifactId>
-	<packaging>war</packaging>
-
-	<parent>
-		<groupId>org.activiti</groupId>
-		<artifactId>activiti-kickstart</artifactId>
-		<version>1.1</version>
-	</parent>
-
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<restlet.version>2.0.14</restlet.version>
-	</properties>
-
-	<build>
-		<plugins>
-			<!-- A simple Jetty test server at http://localhost:8080/activiti-webapp-rest 
-				can be launched with the Maven goal jetty:run and stopped with jetty:stop -->
-			<plugin>
-				<groupId>org.mortbay.jetty</groupId>
-				<artifactId>maven-jetty-plugin</artifactId>
-				<version>6.1.24</version>
-				<configuration>
-
-					<stopPort>9966</stopPort>
-					<stopKey>activiti-webapp-rest</stopKey>
-					<!-- Redeploy every x seconds if changes are detected, 0 for no automatic redeployment -->
-					<scanIntervalSeconds>0</scanIntervalSeconds>
-					<!-- make sure Jetty also finds the widgetset -->
-					<webAppConfig>
-						<contextPath>/activiti-kickstart</contextPath>
-						<baseResource implementation="org.mortbay.resource.ResourceCollection">
-							<resourcesAsCSV>src/main/webapp</resourcesAsCSV>
-						</baseResource>
-					</webAppConfig>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.zeroturnaround</groupId>
-				<artifactId>jrebel-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>generate-rebel-xml</id>
-						<phase>process-resources</phase>
-						<goals>
-							<goal>generate</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-		<pluginManagement>
-			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings 
-					only. It has no influence on the Maven build itself. -->
-				<plugin>
-					<groupId>org.eclipse.m2e</groupId>
-					<artifactId>lifecycle-mapping</artifactId>
-					<version>1.0.0</version>
-					<configuration>
-						<lifecycleMappingMetadata>
-							<pluginExecutions>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>
-											org.zeroturnaround
-										</groupId>
-										<artifactId>
-											jrebel-maven-plugin
-										</artifactId>
-										<versionRange>
-											[1.0.7,)
-										</versionRange>
-										<goals>
-											<goal>generate</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore></ignore>
-									</action>
-								</pluginExecution>
-							</pluginExecutions>
-						</lifecycleMappingMetadata>
-					</configuration>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-	</build>
-
-	<dependencies>
-
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.5</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.activiti</groupId>
-			<artifactId>activiti-kickstart-java</artifactId>
-			<version>1.1</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.restlet.jee</groupId>
-			<artifactId>org.restlet</artifactId>
-			<version>${restlet.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.restlet.jee</groupId>
-			<artifactId>org.restlet.ext.servlet</artifactId>
-			<version>${restlet.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.restlet.jee</groupId>
-			<artifactId>org.restlet.ext.jackson</artifactId>
-			<version>${restlet.version}</version>
-		</dependency>
-		<!-- Using jackson instead of this <dependency>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">  
+    <modelVersion>4.0.0</modelVersion>  
+    <name>Activiti - KickStart - REST</name>  
+    <artifactId>activiti-kickstart-rest</artifactId>  
+    <packaging>war</packaging>  
+    <parent> 
+        <groupId>org.activiti</groupId>  
+        <artifactId>activiti-kickstart</artifactId>  
+        <version>1.1</version> 
+    </parent>  
+    <properties> 
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>  
+        <restlet.version>2.0.14</restlet.version> 
+    </properties>  
+    <build> 
+        <plugins> 
+            <!-- A simple Jetty test server at http://localhost:8080/activiti-webapp-rest 
+				can be launched with the Maven goal jetty:run and stopped with jetty:stop -->  
+            <plugin> 
+                <groupId>org.mortbay.jetty</groupId>  
+                <artifactId>maven-jetty-plugin</artifactId>  
+                <version>6.1.24</version>  
+                <configuration> 
+                    <stopPort>9966</stopPort>  
+                    <stopKey>activiti-webapp-rest</stopKey>  
+                    <!-- Redeploy every x seconds if changes are detected, 0 for no automatic redeployment -->  
+                    <scanIntervalSeconds>0</scanIntervalSeconds>  
+                    <!-- make sure Jetty also finds the widgetset -->  
+                    <webAppConfig> 
+                        <contextPath>/activiti-kickstart</contextPath>  
+                        <baseResource implementation="org.mortbay.resource.ResourceCollection"> 
+                            <resourcesAsCSV>src/main/webapp</resourcesAsCSV> 
+                        </baseResource> 
+                    </webAppConfig> 
+                </configuration> 
+            </plugin>  
+            <plugin> 
+                <groupId>org.zeroturnaround</groupId>  
+                <artifactId>jrebel-maven-plugin</artifactId>  
+                <executions> 
+                    <execution> 
+                        <id>generate-rebel-xml</id>  
+                        <phase>process-resources</phase>  
+                        <goals> 
+                            <goal>generate</goal> 
+                        </goals> 
+                    </execution> 
+                </executions> 
+            </plugin> 
+        </plugins>  
+        <pluginManagement> 
+            <plugins> 
+                <!--This plugin's configuration is used to store Eclipse m2e settings 
+					only. It has no influence on the Maven build itself. -->  
+                <plugin> 
+                    <groupId>org.eclipse.m2e</groupId>  
+                    <artifactId>lifecycle-mapping</artifactId>  
+                    <version>1.0.0</version>  
+                    <configuration> 
+                        <lifecycleMappingMetadata> 
+                            <pluginExecutions> 
+                                <pluginExecution> 
+                                    <pluginExecutionFilter> 
+                                        <groupId>org.zeroturnaround</groupId>  
+                                        <artifactId>jrebel-maven-plugin</artifactId>  
+                                        <versionRange>[1.0.7,)</versionRange>  
+                                        <goals> 
+                                            <goal>generate</goal> 
+                                        </goals> 
+                                    </pluginExecutionFilter>  
+                                    <action> 
+                                        <ignore/> 
+                                    </action> 
+                                </pluginExecution> 
+                            </pluginExecutions> 
+                        </lifecycleMappingMetadata> 
+                    </configuration> 
+                </plugin> 
+            </plugins> 
+        </pluginManagement> 
+    </build>  
+    <dependencies> 
+        <dependency> 
+            <groupId>org.activiti</groupId>  
+            <artifactId>activiti-kickstart-java</artifactId>  
+            <version>1.1</version>  
+            <exclusions> 
+                <exclusion> 
+                    <groupId>javax.xml.bind</groupId>  
+                    <artifactId>jaxb-api</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>com.sun.xml.messaging.saaj</groupId>  
+                    <artifactId>saaj-impl</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>com.sun.xml.bind</groupId>  
+                    <artifactId>jaxb-impl</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>org.livetribe</groupId>  
+                    <artifactId>livetribe-jsr223</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>org.apache.chemistry.opencmis</groupId>  
+                    <artifactId>chemistry-opencmis-client-api</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>javax.mail</groupId>  
+                    <artifactId>mail</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>com.sun.org.apache.xml.internal</groupId>  
+                    <artifactId>resolver</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>com.sun.xml.stream.buffer</groupId>  
+                    <artifactId>streambuffer</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>javax.xml.ws</groupId>  
+                    <artifactId>jaxws-api</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>stax</groupId>  
+                    <artifactId>stax-api</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>com.sun.xml.ws</groupId>  
+                    <artifactId>jaxws-rt</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>javax.activation</groupId>  
+                    <artifactId>activation</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>javax.xml.stream</groupId>  
+                    <artifactId>stax-api</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>com.sun.xml.ws</groupId>  
+                    <artifactId>jaxws-rt</artifactId> 
+                </exclusion> 
+            </exclusions> 
+        </dependency>  
+        <dependency> 
+            <groupId>org.restlet.jee</groupId>  
+            <artifactId>org.restlet</artifactId>  
+            <version>${restlet.version}</version> 
+        </dependency>  
+        <dependency> 
+            <groupId>org.restlet.jee</groupId>  
+            <artifactId>org.restlet.ext.servlet</artifactId>  
+            <version>${restlet.version}</version> 
+        </dependency>  
+        <dependency> 
+            <groupId>org.restlet.jee</groupId>  
+            <artifactId>org.restlet.ext.jackson</artifactId>  
+            <version>${restlet.version}</version> 
+        </dependency>  
+        <!-- Using jackson instead of this <dependency>
 			<groupId>org.restlet.jee</groupId>
 			<artifactId>org.restlet.ext.json</artifactId>
 			<version>${restlet.version}</version>
-		</dependency> -->
-		<dependency>
-			<groupId>org.restlet.jee</groupId>
-			<artifactId>org.restlet.ext.fileupload</artifactId>
-			<version>${restlet.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
-		</dependency>
-		<dependency>
-			<groupId>commons-fileupload</groupId>
-			<artifactId>commons-fileupload</artifactId>
-			<version>1.2.2</version>
-		</dependency>
-
-	</dependencies>
-
-	<repositories>
-		<repository>
-			<id>maven-restlet</id>
-			<name>Public online Restlet repository</name>
-			<url>http://maven.restlet.org</url>
-		</repository>
-	</repositories>
-
+		</dependency> -->  
+        <dependency> 
+            <groupId>org.restlet.jee</groupId>  
+            <artifactId>org.restlet.ext.fileupload</artifactId>  
+            <version>${restlet.version}</version> 
+        </dependency>  
+        <dependency> 
+            <groupId>commons-io</groupId>  
+            <artifactId>commons-io</artifactId>  
+            <version>2.4</version> 
+        </dependency>  
+        <dependency> 
+            <groupId>commons-fileupload</groupId>  
+            <artifactId>commons-fileupload</artifactId>  
+            <version>1.2.2</version> 
+        </dependency> 
+    </dependencies>  
+    <repositories> 
+        <repository> 
+            <id>maven-restlet</id>  
+            <name>Public online Restlet repository</name>  
+            <url>http://maven.restlet.org</url> 
+        </repository> 
+    </repositories>  
+    <dependencyManagement> 
+        <dependencies> 
+            <dependency> 
+                <groupId>org.codehaus.woodstox</groupId>  
+                <artifactId>wstx-asl</artifactId>  
+                <version>3.2.3</version> 
+            </dependency>  
+            <dependency> 
+                <groupId>org.jvnet.staxex</groupId>  
+                <artifactId>stax-ex</artifactId>  
+                <version>1.2</version> 
+            </dependency>  
+            <dependency> 
+                <groupId>org.jvnet</groupId>  
+                <artifactId>mimepull</artifactId>  
+                <version>1.3</version> 
+            </dependency> 
+        </dependencies> 
+    </dependencyManagement> 
 </project>

--- a/activiti-kickstart-ui/pom.xml
+++ b/activiti-kickstart-ui/pom.xml
@@ -1,146 +1,210 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
 
-    <name>Activiti - KickStart - UI</name>
-    <artifactId>activiti-kickstart-ui</artifactId>
-    <packaging>war</packaging>
-
-    <parent>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-kickstart</artifactId>
-        <version>1.1</version>
-    </parent>
-
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                    <showDeprecation>true</showDeprecation>
-                    <showWarnings>true</showWarnings>
-                    <optimize>true</optimize>
-                </configuration>
-            </plugin>
-            <plugin>
-				<groupId>org.zeroturnaround</groupId>
-				<artifactId>jrebel-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>generate-rebel-xml</id>
-						<phase>process-resources</phase>
-						<goals>
-							<goal>generate</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">  
+    <modelVersion>4.0.0</modelVersion>  
+    <name>Activiti - KickStart - UI</name>  
+    <artifactId>activiti-kickstart-ui</artifactId>  
+    <packaging>war</packaging>  
+    <parent> 
+        <groupId>org.activiti</groupId>  
+        <artifactId>activiti-kickstart</artifactId>  
+        <version>1.1</version> 
+    </parent>  
+    <properties> 
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding> 
+    </properties>  
+    <build> 
+        <plugins> 
+            <plugin> 
+                <groupId>org.apache.maven.plugins</groupId>  
+                <artifactId>maven-compiler-plugin</artifactId>  
+                <configuration> 
+                    <source>1.6</source>  
+                    <target>1.6</target>  
+                    <showDeprecation>true</showDeprecation>  
+                    <showWarnings>true</showWarnings>  
+                    <optimize>true</optimize> 
+                </configuration> 
+            </plugin>  
+            <plugin> 
+                <groupId>org.zeroturnaround</groupId>  
+                <artifactId>jrebel-maven-plugin</artifactId>  
+                <executions> 
+                    <execution> 
+                        <id>generate-rebel-xml</id>  
+                        <phase>process-resources</phase>  
+                        <goals> 
+                            <goal>generate</goal> 
+                        </goals> 
+                    </execution> 
+                </executions> 
+            </plugin>  
             <!-- A simple Jetty test server at http://localhost:8081/activiti-kickstart
-                   can be launched with the Maven goal jetty:run and stopped with jetty:stop -->
-            <plugin>
-                <groupId>org.mortbay.jetty</groupId>
-                <artifactId>maven-jetty-plugin</artifactId>
-                <version>6.1.24</version>
-                <configuration>
-                    <connectors>
-                        <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
-                            <port>8888</port>
-                            <maxIdleTime>60000</maxIdleTime>
-                        </connector>
-                    </connectors>
-                    <stopPort>9966</stopPort>
-                    <stopKey>activiti-kickstartc</stopKey>
-                    <!-- Redeploy every x seconds if changes are detected, 0 for no automatic redeployment -->
-                    <scanIntervalSeconds>0</scanIntervalSeconds>
-                    <!-- make sure Jetty also finds the widgetset -->
-                    <webAppConfig>
-                        <contextPath>/activiti-kickstart-ui</contextPath>
-                        <baseResource implementation="org.mortbay.resource.ResourceCollection">
-                            <!-- Workaround for Maven/Jetty issue http://jira.codehaus.org/browse/JETTY-680 -->
-                            <!-- <resources>src/main/webapp,${project.build.directory}/${project.build.finalName}</resources> -->
-                            <!-- <resourcesAsCSV>src/main/webapp,${project.build.directory}/${project.build.finalName}</resourcesAsCSV> -->
-                            <resourcesAsCSV>src/main/webapp</resourcesAsCSV>
-                        </baseResource>
-                    </webAppConfig>
-                </configuration>
-            </plugin>
-        </plugins>
-        <pluginManagement>
-        	<plugins>
-        		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-        		<plugin>
-        			<groupId>org.eclipse.m2e</groupId>
-        			<artifactId>lifecycle-mapping</artifactId>
-        			<version>1.0.0</version>
-        			<configuration>
-        				<lifecycleMappingMetadata>
-        					<pluginExecutions>
-        						<pluginExecution>
-        							<pluginExecutionFilter>
-        								<groupId>
-        									org.zeroturnaround
-        								</groupId>
-        								<artifactId>
-        									jrebel-maven-plugin
-        								</artifactId>
-        								<versionRange>
-        									[1.0.7,)
-        								</versionRange>
-        								<goals>
-        									<goal>generate</goal>
-        								</goals>
-        							</pluginExecutionFilter>
-        							<action>
-        								<ignore></ignore>
-        							</action>
-        						</pluginExecution>
-        					</pluginExecutions>
-        				</lifecycleMappingMetadata>
-        			</configuration>
-        		</plugin>
-        	</plugins>
-        </pluginManagement>
-    </build>
-
-    <dependencies>
-        <!-- Kickstart service (Java) -->
-        <dependency>
-            <groupId>org.activiti</groupId>
-            <artifactId>activiti-kickstart-java</artifactId>
-            <version>1.1</version>
-        </dependency>
-        <!-- Vaadin dependencies -->
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin</artifactId>
-            <version>6.7.9</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-			<version>2.5</version>
-			<scope>provided</scope>
-        </dependency>
-        <!-- Spring -->
-        <dependency>
-			<groupId>org.activiti</groupId>
-			<artifactId>activiti-spring</artifactId>
-			<version>${activiti.version}</version>
-		</dependency>
-        <dependency>
-      		<groupId>org.springframework</groupId>
-      		<artifactId>spring-web</artifactId>
-      		<version>3.1.0.RELEASE</version>
-    	</dependency>
-    </dependencies>
-
+                   can be launched with the Maven goal jetty:run and stopped with jetty:stop -->  
+            <plugin> 
+                <groupId>org.mortbay.jetty</groupId>  
+                <artifactId>maven-jetty-plugin</artifactId>  
+                <version>6.1.24</version>  
+                <configuration> 
+                    <connectors> 
+                        <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector"> 
+                            <port>8888</port>  
+                            <maxIdleTime>60000</maxIdleTime> 
+                        </connector> 
+                    </connectors>  
+                    <stopPort>9966</stopPort>  
+                    <stopKey>activiti-kickstartc</stopKey>  
+                    <!-- Redeploy every x seconds if changes are detected, 0 for no automatic redeployment -->  
+                    <scanIntervalSeconds>0</scanIntervalSeconds>  
+                    <!-- make sure Jetty also finds the widgetset -->  
+                    <webAppConfig> 
+                        <contextPath>/activiti-kickstart-ui</contextPath>  
+                        <baseResource implementation="org.mortbay.resource.ResourceCollection"> 
+                            <!-- Workaround for Maven/Jetty issue http://jira.codehaus.org/browse/JETTY-680 -->  
+                            <!-- <resources>src/main/webapp,${project.build.directory}/${project.build.finalName}</resources> -->  
+                            <!-- <resourcesAsCSV>src/main/webapp,${project.build.directory}/${project.build.finalName}</resourcesAsCSV> -->  
+                            <resourcesAsCSV>src/main/webapp</resourcesAsCSV> 
+                        </baseResource> 
+                    </webAppConfig> 
+                </configuration> 
+            </plugin> 
+        </plugins>  
+        <pluginManagement> 
+            <plugins> 
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->  
+                <plugin> 
+                    <groupId>org.eclipse.m2e</groupId>  
+                    <artifactId>lifecycle-mapping</artifactId>  
+                    <version>1.0.0</version>  
+                    <configuration> 
+                        <lifecycleMappingMetadata> 
+                            <pluginExecutions> 
+                                <pluginExecution> 
+                                    <pluginExecutionFilter> 
+                                        <groupId>org.zeroturnaround</groupId>  
+                                        <artifactId>jrebel-maven-plugin</artifactId>  
+                                        <versionRange>[1.0.7,)</versionRange>  
+                                        <goals> 
+                                            <goal>generate</goal> 
+                                        </goals> 
+                                    </pluginExecutionFilter>  
+                                    <action> 
+                                        <ignore/> 
+                                    </action> 
+                                </pluginExecution> 
+                            </pluginExecutions> 
+                        </lifecycleMappingMetadata> 
+                    </configuration> 
+                </plugin> 
+            </plugins> 
+        </pluginManagement> 
+    </build>  
+    <dependencies> 
+        <!-- Kickstart service (Java) -->  
+        <dependency> 
+            <groupId>org.activiti</groupId>  
+            <artifactId>activiti-kickstart-java</artifactId>  
+            <version>1.1</version>  
+            <exclusions> 
+                <exclusion> 
+                    <groupId>javax.xml.bind</groupId>  
+                    <artifactId>jaxb-api</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>com.sun.xml.messaging.saaj</groupId>  
+                    <artifactId>saaj-impl</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>com.sun.xml.bind</groupId>  
+                    <artifactId>jaxb-impl</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>org.apache.chemistry.opencmis</groupId>  
+                    <artifactId>chemistry-opencmis-client-api</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>org.livetribe</groupId>  
+                    <artifactId>livetribe-jsr223</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>javax.mail</groupId>  
+                    <artifactId>mail</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>javax.xml.ws</groupId>  
+                    <artifactId>jaxws-api</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>com.sun.xml.stream.buffer</groupId>  
+                    <artifactId>streambuffer</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>com.sun.org.apache.xml.internal</groupId>  
+                    <artifactId>resolver</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>stax</groupId>  
+                    <artifactId>stax-api</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>javax.activation</groupId>  
+                    <artifactId>activation</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>com.sun.xml.ws</groupId>  
+                    <artifactId>jaxws-rt</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>javax.xml.stream</groupId>  
+                    <artifactId>stax-api</artifactId> 
+                </exclusion>  
+                <exclusion> 
+                    <groupId>com.sun.xml.ws</groupId>  
+                    <artifactId>jaxws-rt</artifactId> 
+                </exclusion> 
+            </exclusions> 
+        </dependency>  
+        <!-- Vaadin dependencies -->  
+        <dependency> 
+            <groupId>com.vaadin</groupId>  
+            <artifactId>vaadin</artifactId>  
+            <version>6.7.9</version> 
+        </dependency>  
+        <dependency> 
+            <groupId>javax.servlet</groupId>  
+            <artifactId>servlet-api</artifactId>  
+            <version>2.5</version>  
+            <scope>provided</scope> 
+        </dependency>  
+        <!-- Spring -->  
+        <dependency> 
+            <groupId>org.activiti</groupId>  
+            <artifactId>activiti-spring</artifactId>  
+            <version>${activiti.version}</version> 
+        </dependency>  
+        <dependency> 
+            <groupId>org.springframework</groupId>  
+            <artifactId>spring-web</artifactId>  
+            <version>3.1.0.RELEASE</version> 
+        </dependency> 
+    </dependencies>  
+    <dependencyManagement> 
+        <dependencies> 
+            <dependency> 
+                <groupId>org.codehaus.woodstox</groupId>  
+                <artifactId>wstx-asl</artifactId>  
+                <version>3.2.3</version> 
+            </dependency>  
+            <dependency> 
+                <groupId>org.jvnet.staxex</groupId>  
+                <artifactId>stax-ex</artifactId>  
+                <version>1.2</version> 
+            </dependency>  
+            <dependency> 
+                <groupId>org.jvnet</groupId>  
+                <artifactId>mimepull</artifactId>  
+                <version>1.3</version> 
+            </dependency> 
+        </dependencies> 
+    </dependencyManagement> 
 </project>


### PR DESCRIPTION
@jbarrez Hi, I am a user of project **_org.activiti:activiti-kickstart-rest:1.1_**. I found that its pom file introduced **_50_** dependencies. However, among them, **_19_** libraries (**_38%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_org.activiti:activiti-kickstart-rest:1.1_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.jvnet:mimepull:jar:1.3:compile
org.apache.chemistry.opencmis:chemistry-opencmis-client-api:jar:0.7.0:compile
com.sun.xml.ws:jaxws-rt:jar:2.1.7:compile
com.sun.xml.messaging.saaj:saaj-impl:jar:1.3.3:compile
com.sun.xml.bind:jaxb-impl:jar:2.1.7:compile
com.sun.xml.stream.buffer:streambuffer:jar:0.9:compile
org.codehaus.woodstox:wstx-asl:jar:3.2.3:compile
org.livetribe:livetribe-jsr223:jar:2.0.6:compile
com.sun.org.apache.xml.internal:resolver:jar:20050927:compile
javax.xml.ws:jaxws-api:jar:2.1:compile
javax.mail:mail:jar:1.4.1:compile
javax.activation:activation:jar:1.1:compile
org.jvnet.staxex:stax-ex:jar:1.2:compile
javax.xml.bind:jaxb-api:jar:2.2.1:compile
junit:junit:jar:3.8:compile
javax.xml.stream:stax-api:jar:1.0-2:compile
javax.servlet:servlet-api:jar:2.5:compile
javax.xml.soap:saaj-api:jar:1.3:compile
stax:stax-api:jar:1.0.1:compile
</code></pre>
